### PR TITLE
Allow NaN values in unsupervised random forest

### DIFF
--- a/.gitmodules
+++ b/.gitmodules
@@ -1,4 +1,4 @@
 [submodule "treeple/_lib/sklearn"]
 	path = treeple/_lib/sklearn_fork
-	url = https://github.com/neurodata/scikit-learn
+	url = https://github.com/weioren/scikit-learn
 	branch = submodulev3

--- a/.gitmodules
+++ b/.gitmodules
@@ -1,4 +1,4 @@
 [submodule "treeple/_lib/sklearn"]
 	path = treeple/_lib/sklearn_fork
-	url = https://github.com/weioren/scikit-learn
+	url = https://github.com/neurodata/scikit-learn
 	branch = submodulev3

--- a/treeple/ensemble/_unsupervised_forest.py
+++ b/treeple/ensemble/_unsupervised_forest.py
@@ -95,6 +95,7 @@ class ForestCluster(SimMatrixMixin, TransformerMixin, ClusterMixin, BaseForest):
             self,
             X,
             dtype=DTYPE,  # accept_sparse="csc",
+            ensure_all_finite="allow-nan"
         )
         if sample_weight is not None:
             sample_weight = _check_sample_weight(sample_weight, X)

--- a/treeple/ensemble/_unsupervised_forest.py
+++ b/treeple/ensemble/_unsupervised_forest.py
@@ -92,10 +92,7 @@ class ForestCluster(SimMatrixMixin, TransformerMixin, ClusterMixin, BaseForest):
         """
         # Validate or convert input data
         X = validate_data(
-            self,
-            X,
-            dtype=DTYPE,  # accept_sparse="csc",
-            ensure_all_finite="allow-nan"
+            self, X, dtype=DTYPE, ensure_all_finite="allow-nan"  # accept_sparse="csc",
         )
         if sample_weight is not None:
             sample_weight = _check_sample_weight(sample_weight, X)


### PR DESCRIPTION
<!--
Thanks for contributing a pull request! Please ensure you have taken a look at
the contribution guidelines from scikit-learn: https://github.com/scikit-learn/scikit-learn/blob/main/CONTRIBUTING.md
-->

#### Reference Issues/PRs
<!--
Example: Fixes #1234. See also #3456.
Please use keywords (e.g., Fixes) to create link to the issues or pull requests
you resolved, so that they will automatically be closed when your pull request
is merged. See https://github.com/blog/1506-closing-issues-via-pull-requests
-->


#### What does this implement/fix? Explain your changes.
Changed _fit_ function in __unsupervised_forest.py_ to add ensure_all_finite = "allow-nan" parameter to ensure NaN values are always allowed.

#### Any other comments?


<!--
Please be aware that we are a loose team of volunteers so patience is
necessary; assistance handling other issues is very welcome. We value
all user contributions, no matter how minor they are.

See https://github.com/neurodata/treeple/blob/main/CONTRIBUTING.md for more
information on contributing.

Thanks for contributing!
-->
