### PR TITLE
Fast oblique

### DIFF
--- a/treeple/ensemble/_supervised_forest.py
+++ b/treeple/ensemble/_supervised_forest.py
@@ -281,6 +281,7 @@ class ObliqueRandomForestClassifier(
             list,
             None,
         ],
+        "sampling_method": [StrOptions({"fisher", "floyd"})],
     }
     _parameter_constraints.pop("splitter")
 
@@ -305,6 +306,7 @@ class ObliqueRandomForestClassifier(
         class_weight=None,
         max_samples=None,
         feature_combinations=None,
+        sampling_method="floyd",
     ):
         super().__init__(
             estimator=ObliqueDecisionTreeClassifier(),
@@ -320,6 +322,7 @@ class ObliqueRandomForestClassifier(
                 "min_impurity_decrease",
                 "random_state",
                 "feature_combinations",
+                "sampling_method",
             ),
             bootstrap=bootstrap,
             oob_score=oob_score,
@@ -336,6 +339,7 @@ class ObliqueRandomForestClassifier(
         self.min_samples_leaf = min_samples_leaf
         self.max_features = max_features
         self.feature_combinations = feature_combinations
+        self.sampling_method = sampling_method  # new parameters
 
         # unused by oblique forests
         self.min_weight_fraction_leaf = min_weight_fraction_leaf

--- a/treeple/tree/_classes.py
+++ b/treeple/tree/_classes.py
@@ -9,6 +9,7 @@ from sklearn.cluster import AgglomerativeClustering
 from sklearn.utils import check_random_state
 from sklearn.utils._param_validation import Interval
 from sklearn.utils.validation import check_is_fitted, validate_data
+from sklearn.utils._param_validation import StrOptions
 
 from .._lib.sklearn.tree import (
     BaseDecisionTree,
@@ -840,6 +841,7 @@ class ObliqueDecisionTreeClassifier(SimMatrixMixin, DecisionTreeClassifier):
             Interval(Real, 1.0, None, closed="left"),
             None,
         ],
+        "sampling_method": [StrOptions({"floyd", "fisher"})],
     }
 
     def __init__(
@@ -857,6 +859,7 @@ class ObliqueDecisionTreeClassifier(SimMatrixMixin, DecisionTreeClassifier):
         min_impurity_decrease=0.0,
         class_weight=None,
         feature_combinations=None,
+        sampling_method="floyd",
         ccp_alpha=0.0,
         store_leaf_values=False,
         monotonic_cst=None,
@@ -879,6 +882,7 @@ class ObliqueDecisionTreeClassifier(SimMatrixMixin, DecisionTreeClassifier):
         )
 
         self.feature_combinations = feature_combinations
+        self.sampling_method = sampling_method
 
     def _build_tree(
         self,
@@ -973,6 +977,7 @@ class ObliqueDecisionTreeClassifier(SimMatrixMixin, DecisionTreeClassifier):
                 random_state,
                 monotonic_cst,
                 self.feature_combinations_,
+                self.sampling_method,
             )
 
         self.tree_ = ObliqueTree(self.n_features_in_, self.n_classes_, self.n_outputs_)
@@ -1054,6 +1059,7 @@ class ObliqueDecisionTreeClassifier(SimMatrixMixin, DecisionTreeClassifier):
                 random_state,
                 monotonic_cst,
                 self.feature_combinations_,
+                self.sampling_method
             )
 
         # Use BestFirst if max_leaf_nodes given; use DepthFirst otherwise

--- a/treeple/tree/_classes.py
+++ b/treeple/tree/_classes.py
@@ -7,9 +7,8 @@ from scipy.sparse import issparse
 from sklearn.base import ClusterMixin, TransformerMixin
 from sklearn.cluster import AgglomerativeClustering
 from sklearn.utils import check_random_state
-from sklearn.utils._param_validation import Interval
+from sklearn.utils._param_validation import Interval, StrOptions
 from sklearn.utils.validation import check_is_fitted, validate_data
-from sklearn.utils._param_validation import StrOptions
 
 from .._lib.sklearn.tree import (
     BaseDecisionTree,
@@ -1059,7 +1058,7 @@ class ObliqueDecisionTreeClassifier(SimMatrixMixin, DecisionTreeClassifier):
                 random_state,
                 monotonic_cst,
                 self.feature_combinations_,
-                self.sampling_method
+                self.sampling_method,
             )
 
         # Use BestFirst if max_leaf_nodes given; use DepthFirst otherwise

--- a/treeple/tree/_oblique_splitter.pyx
+++ b/treeple/tree/_oblique_splitter.pyx
@@ -11,7 +11,8 @@ from libcpp.vector cimport vector
 
 from .._lib.sklearn.tree._criterion cimport Criterion
 from .._lib.sklearn.tree._utils cimport rand_int, rand_uniform
-from ._utils cimport fisher_yates_shuffle
+# from ._utils cimport fisher_yates_shuffle
+from ._utils cimport floyd_sample_indices
 
 
 cdef float64_t INFINITY = np.inf
@@ -195,8 +196,9 @@ cdef class ObliqueSplitter(BaseObliqueSplitter):
         self.X = X
 
         # create a helper array for allowing efficient Fisher-Yates
-        self.indices_to_sample = np.arange(self.max_features * self.n_features,
-                                           dtype=np.intp)
+        # self.indices_to_sample = np.arange(self.max_features * self.n_features,
+        #                                   dtype=np.intp)
+        self.indices_to_sample = np.arange(self.n_non_zeros, dtype=np.intp)
 
         # XXX: Just to initialize stuff
         # self.feature_weights = np.ones((self.n_features,), dtype=float32_t) / self.n_features
@@ -239,7 +241,9 @@ cdef class ObliqueSplitter(BaseObliqueSplitter):
         cdef intp_t grid_size = self.max_features * self.n_features
 
         # shuffle indices over the 2D grid to sample using Fisher-Yates1
-        fisher_yates_shuffle(indices_to_sample, grid_size, random_state)
+        # fisher_yates_shuffle(indices_to_sample, grid_size, random_state)
+        # Update Fisher Yates Shuffle to Floyd's method
+        floyd_sample_indices(indices_to_sample, n_non_zeros, grid_size, random_state)
 
         # sample 'n_non_zeros' in a mtry X n_features projection matrix
         # which consists of +/- 1's chosen at a 1/2s rate

--- a/treeple/tree/_oblique_splitter.pyx
+++ b/treeple/tree/_oblique_splitter.pyx
@@ -12,7 +12,7 @@ from libcpp.vector cimport vector
 from .._lib.sklearn.tree._criterion cimport Criterion
 from .._lib.sklearn.tree._utils cimport rand_int, rand_uniform
 
-# from ._utils cimport fisher_yates_shuffle
+from ._utils cimport fisher_yates_shuffle
 from ._utils cimport floyd_sample_indices
 
 

--- a/treeple/tree/_oblique_splitter.pyx
+++ b/treeple/tree/_oblique_splitter.pyx
@@ -11,9 +11,7 @@ from libcpp.vector cimport vector
 
 from .._lib.sklearn.tree._criterion cimport Criterion
 from .._lib.sklearn.tree._utils cimport rand_int, rand_uniform
-
-from ._utils cimport fisher_yates_shuffle
-from ._utils cimport floyd_sample_indices
+from ._utils cimport fisher_yates_shuffle, floyd_sample_indices
 
 
 cdef float64_t INFINITY = np.inf

--- a/treeple/tree/_oblique_splitter.pyx
+++ b/treeple/tree/_oblique_splitter.pyx
@@ -11,6 +11,7 @@ from libcpp.vector cimport vector
 
 from .._lib.sklearn.tree._criterion cimport Criterion
 from .._lib.sklearn.tree._utils cimport rand_int, rand_uniform
+
 # from ._utils cimport fisher_yates_shuffle
 from ._utils cimport floyd_sample_indices
 

--- a/treeple/tree/_oblique_splitter.pyx
+++ b/treeple/tree/_oblique_splitter.pyx
@@ -238,7 +238,7 @@ cdef class ObliqueSplitter(BaseObliqueSplitter):
         cdef intp_t[::1] indices_to_sample = self.indices_to_sample
         cdef intp_t grid_size = self.max_features * self.n_features
 
-        # shuffle indices over the 2D grid to sample using Fisher-Yates
+        # shuffle indices over the 2D grid to sample using Fisher-Yates1
         fisher_yates_shuffle(indices_to_sample, grid_size, random_state)
 
         # sample 'n_non_zeros' in a mtry X n_features projection matrix

--- a/treeple/tree/_oblique_splitter.pyx
+++ b/treeple/tree/_oblique_splitter.pyx
@@ -205,7 +205,7 @@ cdef class ObliqueSplitter(BaseObliqueSplitter):
         if self.sampling_method == 0:
             self.indices_to_sample = np.arange(self.max_features * self.n_features,
                                                dtype=np.intp)
-        else:                                    
+        else:
             self.indices_to_sample = np.arange(self.n_non_zeros, dtype=np.intp)
 
         # XXX: Just to initialize stuff

--- a/treeple/tree/_utils.pxd
+++ b/treeple/tree/_utils.pxd
@@ -14,11 +14,19 @@ ctypedef fused vector_or_memview:
     intp_t[::1]
     intp_t[:]
 
-
+'''
 cdef void fisher_yates_shuffle(
     vector_or_memview indices_to_sample,
     intp_t grid_size,
     uint32_t* random_state,
+) noexcept nogil
+'''
+
+cdef void floyd_sample_indices(
+    intp_t[::1] out, 
+    intp_t k, 
+    intp_t n, 
+    uint32_t* random_state
 ) noexcept nogil
 
 

--- a/treeple/tree/_utils.pxd
+++ b/treeple/tree/_utils.pxd
@@ -14,14 +14,6 @@ ctypedef fused vector_or_memview:
     intp_t[::1]
     intp_t[:]
 
-'''
-cdef void fisher_yates_shuffle(
-    vector_or_memview indices_to_sample,
-    intp_t grid_size,
-    uint32_t* random_state,
-) noexcept nogil
-'''
-
 cdef void floyd_sample_indices(
     intp_t[::1] out, 
     intp_t k, 

--- a/treeple/tree/_utils.pxd
+++ b/treeple/tree/_utils.pxd
@@ -14,6 +14,12 @@ ctypedef fused vector_or_memview:
     intp_t[::1]
     intp_t[:]
 
+cdef void fisher_yates_shuffle(
+    vector_or_memview indices_to_sample,
+    intp_t grid_size,
+    uint32_t* random_state,
+) noexcept nogil
+
 cdef void floyd_sample_indices(
     intp_t[::1] out,
     intp_t k,

--- a/treeple/tree/_utils.pxd
+++ b/treeple/tree/_utils.pxd
@@ -15,9 +15,9 @@ ctypedef fused vector_or_memview:
     intp_t[:]
 
 cdef void floyd_sample_indices(
-    intp_t[::1] out, 
-    intp_t k, 
-    intp_t n, 
+    intp_t[::1] out,
+    intp_t k,
+    intp_t n,
     uint32_t* random_state
 ) noexcept nogil
 

--- a/treeple/tree/_utils.pyx
+++ b/treeple/tree/_utils.pyx
@@ -14,33 +14,6 @@ cnp.import_array()
 from .._lib.sklearn.tree._utils cimport rand_int, rand_uniform
 from libcpp.unordered_set cimport unordered_set
 
-''''
-cdef inline void fisher_yates_shuffle(
-    vector_or_memview indices_to_sample,
-    intp_t grid_size,
-    uint32_t* random_state,
-) noexcept nogil:
-    """Shuffle the indices in place using the Fisher-Yates algorithm.
-    Parameters
-    ----------
-    indices_to_sample : A C++ vector or 1D memoryview
-        The indices to shuffle.
-    grid_size : intp_t
-        The size of the grid to shuffle. This is explicitly passed in
-        to support the templated `vector_or_memview` type, which allows
-        for both C++ vectors and Cython memoryviews. Getitng the length
-        of both types uses different API.
-    random_state : uint32_t*
-        The random state.
-    """
-    cdef intp_t i, j
-
-    # XXX: should this be `i` or `i+1`? for valid Fisher-Yates?
-    for i in range(0, grid_size - 1):
-        j = rand_int(i, grid_size, random_state)
-        indices_to_sample[j], indices_to_sample[i] = \
-            indices_to_sample[i], indices_to_sample[j]
-'''
 
 cdef void floyd_sample_indices(
     intp_t[::1] out,

--- a/treeple/tree/_utils.pyx
+++ b/treeple/tree/_utils.pyx
@@ -11,8 +11,9 @@ cimport numpy as cnp
 
 cnp.import_array()
 
-from .._lib.sklearn.tree._utils cimport rand_int, rand_uniform
 from libcpp.unordered_set cimport unordered_set
+
+from .._lib.sklearn.tree._utils cimport rand_int, rand_uniform
 
 ''''
 cdef inline void fisher_yates_shuffle(

--- a/treeple/tree/_utils.pyx
+++ b/treeple/tree/_utils.pyx
@@ -12,8 +12,9 @@ cimport numpy as cnp
 cnp.import_array()
 
 from .._lib.sklearn.tree._utils cimport rand_int, rand_uniform
+from libcpp.unordered_set cimport unordered_set
 
-
+''''
 cdef inline void fisher_yates_shuffle(
     vector_or_memview indices_to_sample,
     intp_t grid_size,
@@ -39,6 +40,26 @@ cdef inline void fisher_yates_shuffle(
         j = rand_int(i, grid_size, random_state)
         indices_to_sample[j], indices_to_sample[i] = \
             indices_to_sample[i], indices_to_sample[j]
+'''
+
+cdef void floyd_sample_indices(
+    intp_t[::1] out,
+    intp_t k,
+    intp_t n,
+    uint32_t* random_state
+) noexcept nogil:
+    cdef unordered_set[intp_t] seen
+    cdef intp_t i, r, count = 0
+
+    for i in range(n - k, n):
+        r = rand_int(0, i + 1, random_state)
+        if seen.find(r) == seen.end():
+            seen.insert(r)
+            out[count] = r
+        else:
+            seen.insert(i)
+            out[count] = i
+        count += 1
 
 
 cdef inline int rand_weighted_binary(

--- a/treeple/tree/_utils.pyx
+++ b/treeple/tree/_utils.pyx
@@ -54,7 +54,7 @@ cdef void floyd_sample_indices(
 
     for i in range(n - k, n):
         r = rand_int(0, i + 1, random_state)
-        if seen.find(r) == seen.end():
+        if seen.find(r) != seen.end():
             seen.insert(r)
             out[count] = r
         else:

--- a/treeple/tree/_utils.pyx
+++ b/treeple/tree/_utils.pyx
@@ -16,6 +16,33 @@ from libcpp.unordered_set cimport unordered_set
 from .._lib.sklearn.tree._utils cimport rand_int, rand_uniform
 
 
+cdef inline void fisher_yates_shuffle(
+    vector_or_memview indices_to_sample,
+    intp_t grid_size,
+    uint32_t* random_state,
+) noexcept nogil:
+    """Shuffle the indices in place using the Fisher-Yates algorithm.
+    Parameters
+    ----------
+    indices_to_sample : A C++ vector or 1D memoryview
+        The indices to shuffle.
+    grid_size : intp_t
+        The size of the grid to shuffle. This is explicitly passed in
+        to support the templated `vector_or_memview` type, which allows
+        for both C++ vectors and Cython memoryviews. Getitng the length
+        of both types uses different API.
+    random_state : uint32_t*
+        The random state.
+    """
+    cdef intp_t i, j
+
+    # XXX: should this be `i` or `i+1`? for valid Fisher-Yates?
+    for i in range(0, grid_size - 1):
+        j = rand_int(i, grid_size, random_state)
+        indices_to_sample[j], indices_to_sample[i] = \
+            indices_to_sample[i], indices_to_sample[j]
+
+
 cdef void floyd_sample_indices(
     intp_t[::1] out,
     intp_t k,


### PR DESCRIPTION
<!--
Thanks for contributing a pull request! Please ensure you have taken a look at
the contribution guidelines from scikit-learn: https://github.com/scikit-learn/scikit-learn/blob/main/CONTRIBUTING.md
-->

#### Reference Issues/PRs
<!--
Example: Fixes #1234. See also #3456.
Please use keywords (e.g., Fixes) to create link to the issues or pull requests
you resolved, so that they will automatically be closed when your pull request
is merged. See https://github.com/blog/1506-closing-issues-via-pull-requests
-->


#### What does this implement/fix? Explain your changes.
Replace Fisher Yates Shuffle by Floyd's method, a more efficient approach to draw uniform distribution from large ranges, in SPORF (i.e. ObliqueRandomForestClassifier). When the projection matrix is huge (i.e. large number of data features and/or max_features), this update would reduce training time significantly without affecting prediction.

#### Any other comments?



<!--
Please be aware that we are a loose team of volunteers so patience is
necessary; assistance handling other issues is very welcome. We value
all user contributions, no matter how minor they are.

See https://github.com/neurodata/treeple/blob/main/CONTRIBUTING.md for more
information on contributing.

Thanks for contributing!
-->
